### PR TITLE
Fixes the Score and Damage GUI

### DIFF
--- a/Assets/Svelto-ECS-Example/Scripts/ECS/EntityDescriptors/HudEntityDescriptorHolder.cs
+++ b/Assets/Svelto-ECS-Example/Scripts/ECS/EntityDescriptors/HudEntityDescriptorHolder.cs
@@ -7,6 +7,6 @@ namespace Svelto.ECS.Example.Survive.HUD
 	{}
 	
     [DisallowMultipleComponent]
-	public class HudEntityDescriptorHolder:GenericEntityDescriptorHolder<HudEntityDescriptor>
+	public class HudEntityDescriptorHolder : GenericEntityDescriptorHolder<HudEntityDescriptor>
 	{}
 }

--- a/Assets/Svelto-ECS-Example/Scripts/ECS/Implementers/GUIImplementors/AnimatorHUDImplementor.cs
+++ b/Assets/Svelto-ECS-Example/Scripts/ECS/Implementers/GUIImplementors/AnimatorHUDImplementor.cs
@@ -2,7 +2,7 @@
 
 namespace Svelto.ECS.Example.Survive.Implementors.HUD
 {
-    public class AnimatorHUDImplementor: MonoBehaviour, IImplementor, IAnimationComponent
+    public class AnimatorHUDImplementor : MonoBehaviour, IImplementor, IAnimationComponent
     {
         Animator        animator;
 

--- a/Assets/Svelto-ECS-Example/Scripts/ECS/Implementers/GUIImplementors/DamageHUDImplementor.cs
+++ b/Assets/Svelto-ECS-Example/Scripts/ECS/Implementers/GUIImplementors/DamageHUDImplementor.cs
@@ -4,7 +4,7 @@ using UnityEngine.UI;
 
 namespace Svelto.ECS.Example.Survive.Implementors.HUD
 {
-    public class DamageHUDImplementor: MonoBehaviour, IImplementor, IDamageHUDComponent
+    public class DamageHUDImplementor : MonoBehaviour, IImplementor, IDamageHUDComponent
     {
         public float flashSpeed = 5f;                               // The speed the damageImage will fade at.
         public Color flashColour = new Color(1f, 0f, 0f, 0.1f);     // The colour the damageImage is set to, to flash.


### PR DESCRIPTION
Unity had trouble detecting the MonoBehavior without a space between the colon in the class declaration.